### PR TITLE
Push all queries through JDatabaseQuery, call onContentPrepare via dispatcher

### DIFF
--- a/media/components/administrator/components/com_jfoobars/models/fields/filters.php
+++ b/media/components/administrator/components/com_jfoobars/models/fields/filters.php
@@ -108,15 +108,15 @@ class JFormFieldFilters extends JFormField
 	{
 		// Get a database object.
 		$db = JFactory::getDBO();
+		$query = $db->getQuery(true);
 
 		// Get the user groups from the database.
-		$db->setQuery(
-			'SELECT a.id AS value, a.title AS text, COUNT(DISTINCT b.id) AS level' .
-			' FROM #__usergroups AS a' .
-			' LEFT JOIN `#__usergroups` AS b ON a.lft > b.lft AND a.rgt < b.rgt' .
-			' GROUP BY a.id' .
-			' ORDER BY a.lft ASC'
-		);
+		$query->select('a.id AS value, a.title AS text, COUNT(DISTINCT b.id) AS level');
+		$query->from($db->quoteName('#__usergroups').' AS a');
+		$query->join('LEFT', $db->quoteName('#__usergroups').' AS b ON a.lft > b.lft AND a.rgt < b.rgt');
+		$query->group('a.id');
+		$query->order('a.lft ASC');
+		$db->setQuery($query);
 		$options = $db->loadObjectList();
 
 		return $options;

--- a/media/components/administrator/components/com_jfoobars/models/fields/modal/jfoobar.php
+++ b/media/components/administrator/components/com_jfoobars/models/fields/modal/jfoobar.php
@@ -53,11 +53,11 @@ class JFormFieldModal_Jfoobar extends JFormField
 		$link	= 'index.php?option=com_jfoobars&amp;view=jfoobars&amp;layout=modal&amp;tmpl=component&amp;function=jSelectJfoobar_'.$this->id;
 
 		$db	= JFactory::getDBO();
-		$db->setQuery(
-			'SELECT title' .
-			' FROM #__jfoobars' .
-			' WHERE id = '.(int) $this->value
-		);
+		$query = $db->getQuery(true);
+		$query->select($db->quoteName('title'));
+		$query->from($db->quoteName('#__jfoobars'));
+		$query->where($db->quoteName('id').' = '.(int) $this->value);
+		$db->setQuery($query);
 		$title = $db->loadResult();
 
 		if ($error = $db->getErrorMsg()) {

--- a/media/components/administrator/components/com_jfoobars/tables/jfoobar.php
+++ b/media/components/administrator/components/com_jfoobars/tables/jfoobar.php
@@ -193,20 +193,21 @@ class JfoobarsTableJfoobar extends JTable
         // Build the WHERE clause for the primary keys.
         $where = $k.'='.implode(' OR '.$k.'=', $pks);
 
+        // Set the JDatabaseQuery object now to work with the below if clause
+        $query = $this->_db->getQuery(true);
+
         // Determine if there is checkin support for the table.
         if (!property_exists($this, 'checked_out') || !property_exists($this, 'checked_out_time')) {
-            $checkin = '';
+            // Do nothing
         } else {
-            $checkin = ' AND (checked_out = 0 OR checked_out = '.(int) $userId.')';
+            $query->where($this->_db->quoteName('checked_out').' = 0 OR '.$this->_db->quoteName('checked_out').' = '.(int) $userId.')');
         }
 
         // Update the publishing state for rows with the given primary keys.
-        $this->_db->setQuery(
-            'UPDATE '.$this->_db->quoteName($this->_tbl).
-            ' SET '.$this->_db->quoteName('state').' = '.(int) $state .
-            ' WHERE ('.$where.')' .
-            $checkin
-        );
+        $query->update($this->_db->quoteName($this->_tbl));
+        $query->set($this->_db->quoteName('state').' = '.(int) $state);
+        $query->where($where);
+        $this->_db->setQuery($query);
         $this->_db->query();
 
         // Check for a database error.

--- a/media/components/site/components/com_jfoobars/views/jfoobar/view.html.php
+++ b/media/components/site/components/com_jfoobars/views/jfoobar/view.html.php
@@ -43,7 +43,7 @@ class JfoobarsViewJfoobar extends JView
 
         $item->event = new stdClass();
         $dispatcher = JDispatcher::getInstance();
-        $item->snippet = JHtml::_('content.prepare', $item->snippet);
+        $item->snippet = $dispatcher->trigger('onContentPrepare', array ('com_jfoobars.jfoobar', $item, $item->params, 0));
 
         $results = $dispatcher->trigger('onContentAfterTitle', array('com_jfoobars.jfoobar', $item, $item->parameters, 0));
         $item->event->afterDisplayTitle = trim(implode("\n", $results));


### PR DESCRIPTION
1) Ensure all queries are handled to the best of their ability by JDatabaseQuery, improves multi-db compatibility if/when it happens

2) The article view calls onContentPrepare via the dispatcher and passes the full $item object, so changed the jfoobar view to do the same.  Why the multi-item views call it through JHtmlContent::prepare, I don't know, but alas, that's how core does it so...
