### PR TITLE
Fix filter on snippet and fullText

### DIFF
--- a/media/component/administrator/components/com_jfoobars/models/forms/jfoobar.xml
+++ b/media/component/administrator/components/com_jfoobars/models/forms/jfoobar.xml
@@ -42,7 +42,7 @@
            class="inputbox"
            label="COM_JFOOBARS_FIELD_SNIPPET_LABEL"
            description="COM_JFOOBARS_FIELD_SNIPPET_DESC"
-           filter="ContactsHelper::filterText"
+           filter="JfoobarsHelper::filterText"
            buttons="false" />
 
        <field
@@ -51,7 +51,7 @@
            class="inputbox"
            label="COM_JFOOBARS_FIELD_FULLTEXT_LABEL"
            description="COM_JFOOBARS_FIELD_FULLTEXT_DESC"
-           filter="ContactsHelper::filterText"
+           filter="JfoobarsHelper::filterText"
            buttons="true" />
 
        <field name="asset_id" type="hidden" filter="unset" />


### PR DESCRIPTION
I came a cropper with this bug and subsequently found that the bug has been raised on Naimbie/jfoobar.
It is simply a case that the forms xml file contains two fields with filter attributes set to "ContactsHelper" rather than the generic/replacable JFoorbarsHelper.  This meant that the validation code wasn't being used and stops the ability to control who can use what html tags and attributes.
